### PR TITLE
Add build target to npm.

### DIFF
--- a/rendering-unit/lib/path_tracer/package.json
+++ b/rendering-unit/lib/path_tracer/package.json
@@ -5,7 +5,8 @@
   "main": "lib.js",
   "scripts": {
     "start": "node lib.js",
-    "test": "node test/test.js"
+    "test": "npm run build && cd ./path_tracer && cargo test && cd ../ && node test/test.js",
+    "build": "cd ./path_tracer ; cargo build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To make our lives easier, we can now
```sh
npm run build
```
from `path_tracer/` to build the library. Additionally, running
```sh
npm test
```
will run both the tests for the Rust library as well as the tests on the JavaScript side.