### PR TITLE
Added upload error handling.

### DIFF
--- a/controller/views/index.pug
+++ b/controller/views/index.pug
@@ -8,4 +8,4 @@ block content
     
     form(method='post', enctype='multipart/form-data', action="/post")
       input(class='text', type='file', name='file-select', accept='.json')
-      input(class='btn btn-primary btn-sm', type='submit', name='upload', value='Upload')
+      input(class='btn btn-primary btn-sm', type='submit', name='upload', value='Upload', disabled)

--- a/controller/views/layout.pug
+++ b/controller/views/layout.pug
@@ -5,6 +5,15 @@ html
     link(rel='stylesheet', href='/vendor/bootstrap/css/bootstrap.min.css')
     link(rel='stylesheet', href='/stylesheets/style.css')
     script(src='https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js')
+    // script to disable/enable upload btn upon valid file select
+    script.
+      $(document).ready(function(){
+        $('input:file').change(function(){
+          if ($(this).val()) {
+              $('input:submit').attr('disabled',false); 
+          }
+        });
+      });
 
     // favicon.ico stuff
     link(rel='apple-touch-icon', sizes='180x180', href='/images/favicon/apple-touch-icon.png')


### PR DESCRIPTION
User will only be able to click the upload button when a file select event is detected.

_Notes: Google Chrome will get rid of current selected file when user cancels the second file select. Seems to be a bug. Workaround is possible -- but perhaps in the future. Firefox works fine._

Closes issue #43 